### PR TITLE
Tumblr の正規表現パターンを修正

### DIFF
--- a/src/resolvers/tumblr.py
+++ b/src/resolvers/tumblr.py
@@ -13,7 +13,7 @@ class tumblr:
 	def __str__(self):
 		return "Tumblr"
 	
-	regexStr = "^http://(?:([\\w\\-]+\\.tumblr\\.com)/post/(\\d+)(?:/(?:[\\w\\-]+/?)?)?|tmblr\\.co/([\\w\\-]+))(?:\\?.*)?$"
+	regexStr = r"^http://(?:([\w\-]+\.tumblr\.com)/(?:post|image)/(\d+)(?:/(?:[\w\-]+/?)?)?|tmblr\.co/([\w\-]+))(?:\?.*)?$"
 	regex = re.compile(regexStr, re.IGNORECASE)
 	
 	expandedRegex = re.compile("^http://([\\w\\.\\-]+)/post/(\\d+)(?:/(?:[\\w\\-]+/?)?)?$", re.IGNORECASE)


### PR DESCRIPTION
`http://hogehoge.tumblr.com/image/xxxxxxxxxxxxx` のように `post` ではなく `image` が付いているURLに対応

ex. http://nostrict.tumblr.com/image/40258401392
